### PR TITLE
FIX for deprecated index_last and ADD of dot as argument for all files

### DIFF
--- a/src/main.v
+++ b/src/main.v
@@ -43,8 +43,19 @@ fn treat_file(filename string, mut tags []string) {
 
 fn main() {
 	args := os.args[1..]
+	mut files := []string{}
+	if args[0] == '.' {
+		raw_file_list := os.glob('*.v') or {
+			eprintln('Error listing files on pattern "*.v": ${err}')
+			return
+		}
+		files = raw_file_list.clone()
+	} else {
+		files = args.clone()
+	}
+
 	mut tags := []string{}
-	for filename in args {
+	for filename in files {
 		treat_file(filename, mut tags)
 	}
 	if tags.len > 0 {

--- a/src/main.v
+++ b/src/main.v
@@ -24,7 +24,7 @@ fn treat_file(filename string, mut tags []string) {
 		return
 	}
 	mut base := os.file_name(filename)
-	pos := base.index_last('.') or { -1 }
+	pos := base.last_index('.') or { -1 }
 	if pos != -1 {
 		base = base[..pos]
 	}


### PR DESCRIPTION
FIX: index_last is deprecated in favor of last_index

ADD: You can now use a dot as single argument to include all .v -files in your current directory.